### PR TITLE
Fix CI build failure for RocksDB redundant move

### DIFF
--- a/.github/workflows/typesense-build-release.yml
+++ b/.github/workflows/typesense-build-release.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           set -euxo pipefail
           if [[ -x "./build.sh" ]]; then
-            ./build.sh --package-binary
+            CXXFLAGS="$CXXFLAGS -Wno-error=redundant-move" ./build.sh --package-binary
             TAR="$(ls -1 build-*/${{ env.BIN_NAME }}-*.tar.gz | head -n1)"
             echo "TARBALL=$TAR" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Summary
- disable `-Werror=redundant-move` when running upstream `build.sh`

## Testing
- `yamllint .github/workflows/typesense-build-release.yml` *(fails: line-length, empty-lines)*
- `CXXFLAGS="$CXXFLAGS -Wno-error=redundant-move" ./build.sh --package-binary > /tmp/build.log && tail -n 20 /tmp/build.log` *(fails: exceeded time/resource limits)*

------
https://chatgpt.com/codex/tasks/task_b_68b72c88379c83338013feb09be61ace